### PR TITLE
修正smallcart4 從假資料到串接database過渡期產生的問題(還有rounter漏掉沒更新的地方

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,6 @@ import Carousel2 from "./components/Carousel2.vue";
 import StoreInfo5 from "./components/StoreInfo5.vue";
 import Footer from "./components/Footer.vue";
 import ProductList from "./views/ProductList.vue";
-import Footer from "./components/Footer.vue";
 import GoogleLoginButton from './components/googleLogin.vue'
 </script>
 

--- a/src/components/SmallCart4.vue
+++ b/src/components/SmallCart4.vue
@@ -24,11 +24,11 @@
   
         <div
           class="cartContent"
-          :class="{ empty: cartItems.length === 0 }"
+          :class="{ empty:cartItems && cartItems.length === 0 }"
         >
           <!-- 如果購物車為空 -->
           <p
-            v-if="cartItems.length === 0"
+            v-if="cartItems && cartItems.length === 0"
             class="emptyCart"
           >
             你的購物車是空的
@@ -53,7 +53,7 @@
             </button>
           </div>
   
-          <div class="cartFooter" v-if="cartItems.length > 0">
+          <div class="cartFooter" v-if="cartItems && cartItems.length > 0">
             <router-link to="/Cart" class="checkoutBtn">
               訂單結帳
             </router-link>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -75,7 +75,7 @@ const router = createRouter({
 		{
 			path: "/store-info",
 			name: "store-info",
-			component: StoreInfo4,
+			component: StoreInfo5,
 		},
 		{
 			path: "/users/edit",


### PR DESCRIPTION
只是暫時讓網頁能繼續顯示而已，根本問題仍在於檔案收不到database來的資料。目前按照頌偉的方法改過後，仍會有其他報錯，諸如:Uncaught (in promise) Error: currentPage/current-page is now deprecated, use v-model instead to set the current page.
    at setup (vue-awesome-paginate.js?v=b9bbfe3f:287:13)
    at callWithErrorHandling (chunk-UQWBJQZ5.js?v=b9bbfe3f:2263:19)
    at setupStatefulComponent (chunk-UQWBJQZ5.js?v=b9bbfe3f:9983:25)
    at setupComponent (chunk-UQWBJQZ5.js?v=b9bbfe3f:9944:36)
    at mountComponent (chunk-UQWBJQZ5.js?v=b9bbfe3f:7300:7)
    at processComponent (chunk-UQWBJQZ5.js?v=b9bbfe3f:7266:9)
    at patch (chunk-UQWBJQZ5.js?v=b9bbfe3f:6782:11)
    at mountChildren (chunk-UQWBJQZ5.js?v=b9bbfe3f:7014:7)
    at mountElement (chunk-UQWBJQZ5.js?v=b9bbfe3f:6937:7)
    at processElement (chunk-UQWBJQZ5.js?v=b9bbfe3f:6902:7)
gpt的解釋是"這個報錯表明你在使用的 Vue 分頁套件（vue-awesome-paginate）中，某個屬性（currentPage 或 current-page）已經被棄用。該套件現在要求使用 v-model 來管理當前頁碼。"