### PR TITLE
調整 google login 按鈕位置、設置重定向、註冊登入相關調整

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,7 @@
 <script setup>
 import { RouterLink, RouterView } from "vue-router";
 import NavBar from "./components/NavBar.vue";
-import HomeView from "./views/HomeView.vue";
-import Carousel from "./components/Carousel.vue";
-import StoreInfo4 from "./components/StoreInfo.vue";
-import ProductList from "./views/ProductList.vue";
 import Footer from "./components/Footer.vue";
-import GoogleLoginButton from './components/googleLogin.vue'
 </script>
 
 <template>
@@ -47,7 +42,6 @@ import GoogleLoginButton from './components/googleLogin.vue'
       <RouterLink to="/products/detail">products-detail</RouterLink>
     </nav>
   </header>
-  <GoogleLoginButton />
   <RouterView />
   <!-- <Carousel/> -->
   <!-- <StoreInfo4/> -->

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -2,6 +2,8 @@
 import SmallCart from './SmallCart.vue';
 import { ref, computed} from 'vue';
 import { useProductStore } from '@/stores/products';  // 引入 Pinia store
+import { RouterLink, RouterView } from "vue-router";
+
 
 const productStore = useProductStore(); // 使用 Pinia store
 const cartItemCount = computed(() => productStore.cartItemCount);  // 从 store 获取购物车商品总数量
@@ -12,6 +14,8 @@ const cartOpen = ref(false);
 const changeLanguageOpen = ref(false);
 const moneyOpen = ref(false);
 const overlayOpen = ref(false);
+const isLoggedIn = ref(!!localStorage.getItem('UID'))
+
 
 const inputShow = () => {
   isVisible.value = !isVisible.value;
@@ -212,9 +216,11 @@ const closeCart = () => {
       <li class="hidden mx-3 text-black cursor-pointer xl:block hover:text-gray-500">
         <font-awesome-icon :icon="['fas', 'comment']" />
       </li>
+      <Router-link :to="isLoggedIn ? '/users/edit' : '/users/sign-in'" >
       <li class="mx-3 text-black cursor-pointer hover:text-gray-500">
         <font-awesome-icon :icon="['fas', 'user']" />
       </li>
+      </Router-link>
       <li class="mx-3 text-black cursor-pointer hover:text-gray-500">
           <label for="cartSidebarSwitch" @click="handleCartIconClick"
             ><font-awesome-icon :icon="['fas', 'bag-shopping']"

--- a/src/components/ProductItem.vue
+++ b/src/components/ProductItem.vue
@@ -1,5 +1,8 @@
 <script setup>
 import { defineProps } from 'vue';
+import router from '@/router'
+import { useRoute } from 'vue-router'
+const route = useRoute()
 
 const props = defineProps({
   title:{
@@ -19,6 +22,45 @@ const props = defineProps({
   },
 })
 
+// 加入購物車
+const handleAddToCart = async () => {
+  // 檢查是否登入
+  const isAuthenticated = !!localStorage.getItem('UID')
+  
+  if (!isAuthenticated) {
+    // 使用 SweetAlert2 顯示提示
+    Swal.fire({
+      title: '請先登入',
+      text: '加入購物車需要先登入會員',
+      showCancelButton: true,
+      confirmButtonText: '前往登入',
+      cancelButtonText: '取消',
+      confirmButtonColor: '#000000',
+      customClass: {
+        confirmButton: 'swal2-confirm-custom'
+      }
+    }).then((result) => {
+      if (result.isConfirmed) {
+        // 導向登入頁面，並記錄當前頁面路徑，這樣之後可以回來 
+        router.push({
+          path: '/users/sign-in',
+          query: { 
+            redirect: route.fullPath
+          }
+        })
+      }
+    })
+    return
+  }
+
+  // 已登入的情況下，執行加入購物車的邏輯
+  try {
+    await addToCart(productId, quantity)
+    // 成功加入購物車的處理...~~ 不是我寫ㄉ
+  } catch (error) {
+    // 錯誤處理...
+  }
+}
 
 </script>
 
@@ -35,8 +77,8 @@ const props = defineProps({
         <div class="px-2.5 pt-2.5 pb-7 mb-6 text-center lg:relative lg:mb-0">
             <p class="mb-1 text-sm">{{ props.title }}</p>
             <p class=" text-base font-black">NT${{ props.price }}</p>
-            <p class="mb-1 text-base text-gray-500 line-through decoration-slate-400	">NT${{ props.orginalPrice }}</p>
-          <button class=" cartButton absolute bottom-4 left-4 right-4 h-8 rounded bg-neutral-100 border-l-neutral-300 lg:bg-white lg:h-10  lg:left-8 lg:right-8 lg:-top-50px lg:hidden">
+            <p class="mb-1 text-base text-gray-500 line-through decoration-slate-400">NT${{ props.orginalPrice }}</p>
+          <button @click="handleAddToCart" class=" cartButton absolute bottom-4 left-4 right-4 h-8 rounded bg-neutral-100 border-l-neutral-300 lg:bg-white lg:h-10  lg:left-8 lg:right-8 lg:-top-50px lg:hidden">
             <i class="fa-solid fa-cart-shopping lg:hidden"></i>
             <p class="hidden lg:block lg:text-sm lg:py-3">加入購物車</p>
           </button>

--- a/src/components/googleLogin.vue
+++ b/src/components/googleLogin.vue
@@ -32,6 +32,7 @@ const handleRegister = async (googleData) => {
   try {
     const response = await axios.post(`${API_URL}/auth/register`, googleData)
     userData.value = response.data.user
+    
     isLoggedIn.value = true // 註冊後直接登入
     localStorage.setItem(STORAGE_KEY, userData.value.userId) // UID 放在 localStorage
 
@@ -53,20 +54,22 @@ const onLogin = (res) => {
   axios.post(`${API_URL}/auth/verify-token`, res, axiosOptions)
     .then((res) => {
       if (res.data.exists) {
-        console.log('用戶資料：', res.data.user) // 看看收到什麼資料
         // 用戶存在（可能是一般註冊或 Google 註冊），直接登入
         userData.value = res.data.user
         isLoggedIn.value = true
         localStorage.setItem(STORAGE_KEY, userData.value.userId) // 改存 UID
-        console.log('登入成功')
       } else {
-        // 用戶不存在，詢問是否要註冊，這邊可以考慮搞個彈窗或是 sweetalert
+        // 用戶不存在，詢問是否要註冊，目前先用 sweetalert        
         Swal.fire({
           title: '註冊確認',
-          text: '此 email 尚未註冊，是否要註冊新帳號？',
+          text: `此 email 尚未註冊，是否要註冊新帳號？ \n ${res.data.googleData.email}`,
           showCancelButton: true,
           confirmButtonText: '註冊',
-          cancelButtonText: '取消'
+          cancelButtonText: '取消',
+          confirmButtonColor: '#000000', // 註冊按鈕設為黑色背景
+          customClass: {
+            confirmButton: 'swal2-confirm-custom' // 自定義class
+          }
         }).then((result) => {
           if (result.isConfirmed) {
             handleRegister(res.data.googleData)
@@ -84,8 +87,7 @@ const handleLogout = () => {
   userData.value = null
   isLoggedIn.value = false
   localStorage.removeItem(STORAGE_KEY) // 移除 localStorage
-  console.log("登出成功");
-  
+
   // 等待 DOM 更新後再重新渲染按鈕
   setTimeout(() => {
     initializeGoogle()
@@ -114,7 +116,7 @@ const initializeGoogle = () => {
   // 渲染 Google 登入按鈕~~~ 可以選樣式啦
   window.google.accounts.id.renderButton(
     document.getElementById("googleButton"),
-    { 
+    {
       theme: "outline",  // outline 或 filled_blue
       size: "large",     // large 或 medium
       shape: "pill", // rectangular 或 pill
@@ -141,3 +143,9 @@ onMounted(() => {
   }
 })
 </script>
+
+<style scoped>
+.swal2-confirm-custom {
+  color: #ffffff !important;
+}
+</style>

--- a/src/components/googleLogin.vue
+++ b/src/components/googleLogin.vue
@@ -16,6 +16,10 @@
 <script setup>
 import { onMounted, ref } from 'vue'
 import axios from 'axios'
+import { useRouter, useRoute } from 'vue-router'
+const router = useRouter()  
+const route = useRoute()
+const redirectUrl = ref('')  // 用 ref 來存儲重定向 URL
 
 
 // CLIENT_ID
@@ -37,6 +41,10 @@ function loginProcess(response) {
 
   // 設置 axios 預設標頭
   axios.defaults.headers.common['Authorization'] = `Bearer ${response.data.token}`;
+
+// 處理重定向
+const redirectPath = route.query.redirect || '/'
+  router.push(redirectPath)
 }
 
 // 處理 google 註冊新用戶
@@ -116,6 +124,9 @@ const handleLogout = () => {
   localStorage.removeItem(STORAGE_JWT_KEY) // 移除 localStorage
   delete axios.defaults.headers.common['Authorization']; // 移除預設標頭
 
+    // 重定向到登入頁
+    router.push('/users/sign-in')
+
   // 等待 DOM 更新後再重新渲染按鈕
   setTimeout(() => {
     initializeGoogle()
@@ -165,6 +176,9 @@ const initializeGoogle = () => {
 }
 
 onMounted(() => {
+  redirectUrl.value = route.query.redirect || '/'
+
+
   // 檢查登入狀態
   const isUserLoggedIn = localStorage.getItem(STORAGE_KEY)
   if (isUserLoggedIn) {

--- a/src/components/googleLogin.vue
+++ b/src/components/googleLogin.vue
@@ -1,6 +1,8 @@
 <template>
   <div v-if="!isLoggedIn">
-    <div id="googleButton"></div>
+    <div class="google-btn-wrapper">
+      <div id="googleButton"></div>
+    </div>
   </div>
   <!-- ↓ 這邊之後會拿掉 -->
   <div v-else class="flex items-center gap-4">
@@ -22,22 +24,39 @@ const CLIENT_ID = "201131820318-om98jaudikrjuraavdmt8o0jlitaf7b1.apps.googleuser
 const API_URL = 'http://localhost:3300'
 // localSrotage 的 key
 const STORAGE_KEY = 'UID'
+const STORAGE_JWT_KEY = 'TwT'
 // data
 const userData = ref(null)
 const isLoggedIn = ref(false)  // 登入狀態
+// methods
+function loginProcess(response) {
+  userData.value = response.data.user
+  isLoggedIn.value = true // 註冊後直接登入
+  localStorage.setItem(STORAGE_KEY, userData.value.userId) // UID 放在 localStorage
+  localStorage.setItem(STORAGE_JWT_KEY, response.data.token) // JWT 放在 localStorage
 
+  // 設置 axios 預設標頭
+  axios.defaults.headers.common['Authorization'] = `Bearer ${response.data.token}`;
+}
 
 // 處理 google 註冊新用戶
 const handleRegister = async (googleData) => {
   try {
     const response = await axios.post(`${API_URL}/auth/register`, googleData)
-    userData.value = response.data.user
-    
-    isLoggedIn.value = true // 註冊後直接登入
-    localStorage.setItem(STORAGE_KEY, userData.value.userId) // UID 放在 localStorage
+
+    loginProcess(response)
 
   } catch (error) {
-    console.error('註冊失敗 QAQ :', error)
+    console.error('註冊失敗 QAQ:', error);
+    Swal.fire({
+      title: '註冊失敗',
+      text: error.message,
+      confirmButtonText: '確認',
+      confirmButtonColor: '#000000', // 註冊按鈕設為黑色背景
+      customClass: {
+        confirmButton: 'swal2-confirm-custom' // 自定義class
+      }
+    })
   }
 }
 
@@ -55,9 +74,7 @@ const onLogin = (res) => {
     .then((res) => {
       if (res.data.exists) {
         // 用戶存在（可能是一般註冊或 Google 註冊），直接登入
-        userData.value = res.data.user
-        isLoggedIn.value = true
-        localStorage.setItem(STORAGE_KEY, userData.value.userId) // 改存 UID
+        loginProcess(res)
       } else {
         // 用戶不存在，詢問是否要註冊，目前先用 sweetalert        
         Swal.fire({
@@ -79,6 +96,15 @@ const onLogin = (res) => {
     })
     .catch((error) => {
       console.error("登入失敗", error)
+      Swal.fire({
+        title: '登入失敗',
+        text: '登入失敗，請稍後再試或連繫客服人員',
+        confirmButtonText: '確認',
+        confirmButtonColor: '#000000', // 註冊按鈕設為黑色背景
+        customClass: {
+          confirmButton: 'swal2-confirm-custom' // 自定義class
+        }
+      })
     })
 }
 
@@ -87,6 +113,8 @@ const handleLogout = () => {
   userData.value = null
   isLoggedIn.value = false
   localStorage.removeItem(STORAGE_KEY) // 移除 localStorage
+  localStorage.removeItem(STORAGE_JWT_KEY) // 移除 localStorage
+  delete axios.defaults.headers.common['Authorization']; // 移除預設標頭
 
   // 等待 DOM 更新後再重新渲染按鈕
   setTimeout(() => {
@@ -113,6 +141,14 @@ const initializeGoogle = () => {
     context: "signin",
   })
 
+  // 獲取容器寬度
+  const container = document.querySelector('.google-btn-wrapper');
+  const containerWidth = container?.offsetWidth || 800;
+
+  // 設定按鈕寬度（確保不小於最小值）
+  const buttonWidth = containerWidth - 40
+
+
   // 渲染 Google 登入按鈕~~~ 可以選樣式啦
   window.google.accounts.id.renderButton(
     document.getElementById("googleButton"),
@@ -121,7 +157,8 @@ const initializeGoogle = () => {
       size: "large",     // large 或 medium
       shape: "pill", // rectangular 或 pill
       text: "signin_with", // signin_with 或 continue_with
-      logo_alignment: "left"
+      logo_alignment: "center",
+      width: buttonWidth
     }
   )
 
@@ -130,10 +167,15 @@ const initializeGoogle = () => {
 onMounted(() => {
   // 檢查登入狀態
   const isUserLoggedIn = localStorage.getItem(STORAGE_KEY)
-  if (isUserLoggedIn === 'true') {
+  if (isUserLoggedIn) {
     // 這邊可以呼叫 API 重新獲取用戶資料
     // 或是導向登入頁面重新登入
     isLoggedIn.value = true
+  }
+  const token = localStorage.getItem(STORAGE_JWT_KEY);
+  if (token) {
+    // 預設帶上標頭
+    axios.defaults.headers.common['Authorization'] = `Bearer ${token}`;
   }
 
   if (window.google) {
@@ -142,9 +184,26 @@ onMounted(() => {
     window.onload = initializeGoogle
   }
 })
+
+// 添加 resize 事件監聽
+window.addEventListener('resize', () => {
+  // 使用 debounce 避免過於頻繁的重新渲染
+  setTimeout(() => {
+    initializeGoogle();
+  }, 250);
+});
 </script>
 
 <style scoped>
+.google-btn-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+}
+
+
+
 .swal2-confirm-custom {
   color: #ffffff !important;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -30,8 +30,8 @@ router.beforeEach((to, from, next) => {
     }
   } 
     // 已登入用戶試圖訪問登入/註冊頁
-    else if (isAuthenticated && (to.path === '/users/sign-in' || to.path === '/users/register')) {
-      next('/')  // 導向首頁
+    else if (isAuthenticated && (to.path === '/users/sign-in')) {
+      next('/users/edit')  // 導向會員頁
     }
     // 其他情況
     else {

--- a/src/main.js
+++ b/src/main.js
@@ -15,8 +15,29 @@ import 'element-plus/dist/index.css'
 import VueAwesomePaginate from "vue-awesome-paginate";
 
 // import the necessary css file
-
 import "vue-awesome-paginate/dist/style.css";
+
+router.beforeEach((to, from, next) => {
+  const isAuthenticated = !!localStorage.getItem('UID')
+  if (to.meta.requireAuth){
+    if (isAuthenticated) {
+      next()
+    } else {
+      next({
+        path: "/users/sign-in",
+        query: { redirect: to.fullPath }
+      })
+    }
+  } 
+    // 已登入用戶試圖訪問登入/註冊頁
+    else if (isAuthenticated && (to.path === '/users/sign-in' || to.path === '/users/register')) {
+      next('/')  // 導向首頁
+    }
+    // 其他情況
+    else {
+      next()
+    }
+})
 
 library.add(fas, fab);
 const app = createApp(App)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -80,6 +80,9 @@ const router = createRouter({
 			path: "/users/edit",
 			name: "users-edit",
 			component: UsersEdit,
+			meta: {
+				requireAuth: true
+			}
 		},
 		{
 			path: "/users/sign-in",
@@ -90,31 +93,49 @@ const router = createRouter({
 			path: "/MemberCoupons",
 			name: "MemberCoupons",
 			component: () => import("../views/MemberCoupons.vue"),
+			meta: {
+				requireAuth: true
+			}
 		},
 		{
 			path: "/MemberMessage",
 			name: "MemberMessage",
 			component: () => import("../views/MemberMessage.vue"),
+			meta: {
+				requireAuth: true
+			}
 		},
 		{
 			path: "/MemberOrder",
 			name: "MemberOrder",
 			component: () => import("../views/MemberOrder.vue"),
+			meta: {
+				requireAuth: true
+			}
 		},
 		{
 			path: "/MemberPoint",
 			name: "MemberPoint",
 			component: () => import("../views/MemberPoint.vue"),
+			meta: {
+				requireAuth: true
+			}
 		},
 		{
 			path: "/MemberShoppingGold",
 			name: "MemberShoppingGold",
 			component: () => import("../views/MemberShoppingGold.vue"),
+			meta: {
+				requireAuth: true
+			}
 		},
 		{
 			path: "/MemberWishList",
 			name: "MemberWishList",
 			component: () => import("../views/MemberWishList.vue"),
+			meta: {
+				requireAuth: true
+			}
 		},
 		{
 			path: "/OrderDetails",
@@ -122,16 +143,19 @@ const router = createRouter({
 			component: () => import("../views/OrderDetails.vue"),
 		},
 		{
-      path: "/products/detail",
-      name: "products-detail(改)",
-      component: () => import("../views/ProductDetail.vue")
-    },
-    {
-    path:'/Cart',
-    name:'Cart',
-    component: Cart
-    },  
-		
+			path: "/products/detail",
+			name: "products-detail(改)",
+			component: () => import("../views/ProductDetail.vue")
+		},
+		{
+			path: '/Cart',
+			name: 'Cart',
+			component: Cart,
+			meta: {
+				requireAuth: true
+			}
+		},
+
 	],
 
 })

--- a/src/views/RegisterLogin.vue
+++ b/src/views/RegisterLogin.vue
@@ -208,7 +208,7 @@ margin: 0;
     width: 100%;
     margin-top: 20px;
     padding: 10px;
-    background-color: #323335;
+    background-color: #bfbfc2;
     border: 0;
     border-radius: 5px;
     color: white;

--- a/src/views/RegisterLogin.vue
+++ b/src/views/RegisterLogin.vue
@@ -130,7 +130,7 @@ export default defineComponent({
             <div class="mt-5 mx-5 no-underline">
                 <input type="checkbox" class="agreeCheck">
                 <label>
-                    我同意網站<a href="https://www.bonnyread.com.tw/about/terms">服務條款</a>及<a href="https://www.bonnyread.com.tw/about/privacy-policy">隱私權政策</a>
+                    我同意網站<a href="https://www.bonnyread.com.tw/about/terms" class=" text-blue-600">服務條款</a>及<a href="https://www.bonnyread.com.tw/about/privacy-policy" class=" text-blue-600">隱私權政策</a>
                 </label>
                 <button class="join">立即加入</button>
             </div>
@@ -148,7 +148,7 @@ export default defineComponent({
                     <input type="text" placeholder="密碼" >
                 </div>
                 <div class="mt-5 grid grid-cols-1 justify-between gap-5 text-sm">
-                    <button class="w-full p-2 bg-[#3493FB] border-0 rounded-md text-white font-extrabold hover:bg-[#6ab0fb] hover:cursor-pointer">開始購物</button>
+                    <button class="w-full p-2 bg-[#000000] border-0 rounded-md text-white font-extrabold hover:bg-[#323335] hover:cursor-pointer">開始購物</button>
                     <a class="mx-auto cursor-pointer text-[#6D7175] no-underline" href="https://www.bonnyread.com.tw/users/password/new">忘記密碼?</a>
                 </div>
                 
@@ -208,7 +208,7 @@ margin: 0;
     width: 100%;
     margin-top: 20px;
     padding: 10px;
-    background-color: #7BB9FC;
+    background-color: #323335;
     border: 0;
     border-radius: 5px;
     color: white;
@@ -217,11 +217,11 @@ margin: 0;
     cursor: auto;
 }
 .join:hover{
-    background-color: #6ab0fb;
+    background-color: #323335;
 }
 
 .agreeCheck:checked ~ .join{
-    background-color: #3493FB;
+    background-color: #000000;
     cursor: pointer;
 }
 </style>

--- a/src/views/RegisterLogin.vue
+++ b/src/views/RegisterLogin.vue
@@ -1,49 +1,55 @@
 <script lang="ts">
 import { defineComponent, ref } from 'vue'
+import GoogleLoginButton from '@/components/googleLogin.vue'
+
 
 export default defineComponent({
-  setup() {
-    // 狀態變數
-    const isLogin = ref(true)
-    const isRegister = ref(false)
+    components: {
+        GoogleLoginButton
+    },
+    setup() {
+        // 狀態變數
+        const isLogin = ref(true)
+        const isRegister = ref(false)
 
-    // 方法
-    const switchToLogin = () => {
-        isLogin.value = true
-        isRegister.value = false
-        
+        // 方法
+        const switchToLogin = () => {
+            isLogin.value = true
+            isRegister.value = false
+
+        }
+        const switchToRegister = () => {
+            isRegister.value = true
+            isLogin.value = false
+        }
+        return {
+            isLogin,
+            isRegister,
+            switchToLogin,
+            switchToRegister
+        }
     }
-    const switchToRegister = () =>{
-      isRegister.value = true
-      isLogin.value = false
-    }
-    return {
-      isLogin,
-      isRegister,
-      switchToLogin,
-      switchToRegister
-    }
-  }
 })
 </script>
 
 <template>
     <div class="max-w-[600px] w-full justify-center m-[75px_auto] flex flex-col border">
         <img src="../assets/register-pic.jpeg" alt="">
-        
-        <div class="w-full grid grid-cols-1 text-center leading-[62px] lg:grid-cols-2">
-            <div class="border hover:cursor-pointer" @click="switchToRegister">註冊會員</div>
-            <div class="border hover:cursor-pointer" @click="switchToLogin">會員登入</div>
+
+        <div class="w-full grid text-center leading-[62px] grid-cols-2">
+            <div class="border hover:cursor-pointer" :class="{ 'bg-white': isRegister, 'bg-gray-100': !isRegister }" @click="switchToRegister">註冊會員</div>
+            <div class="border hover:cursor-pointer" :class="{ 'bg-white': isLogin, 'bg-gray-100': !isLogin }" @click="switchToLogin">會員登入</div>
         </div>
         <!-- 註冊 -->
-        <div class="p-5 mx-auto" v-if="isRegister">
-            <div class="grid grid-cols-1 justify-between gap-5 px-10 pb-5 lg:grid-cols-2">
-                <button class="text-base px-10 border">使用LINE註冊</button>
-                <button class="text-base px-10 border">使用Facebook註冊</button>
-            </div>
+        <div class=" px-5 pt-5 ">
+            <GoogleLoginButton class="w-full" />
+        </div>
+        <div class="p-5 mx-auto w-full" v-if="isRegister">
+            <hr>
+            <p class="pt-4 text-center text-[#6D7175] text-sm">或使用電子信箱註冊</p>
             <form class="informationInput" method="post">
                 <input type="text" placeholder="用戶名" class="input">
-                <select type="text">
+                <select>
                     <option value="">使用Email註冊</option>
                     <option value="">使用手機號碼註冊</option>
                 </select>
@@ -57,7 +63,7 @@ export default defineComponent({
                 <div class="password">
                     <input type="text" placeholder="密碼" >
                 </div>
-                <select type="text">
+                <select>
                     <option value="" disabled selected>性別</option>
                     <option value="">男</option>
                     <option value="">女</option>
@@ -130,11 +136,9 @@ export default defineComponent({
             </div>
         </div>
         <!-- 登入 -->
-        <div class="p-5 mx-auto" v-if="isLogin">
-            <div class="grid grid-cols-1 justify-between gap-5 px-10 pb-5 lg:grid-cols-2">
-                <button class="text-base px-10 border">使用LINE登入</button>
-                <button class="text-base px-10 border">使用Facebook登入</button>
-            </div>
+        <div class="p-5 mx-auto w-full" v-if="isLogin">
+            <hr>
+            <p class="pt-4 text-center text-[#6D7175] text-sm">或使用電子信箱登入</p>
             <div class="informationInput">
                 <div class="emailRegister ">
                     <input type="text" placeholder="電子信箱">
@@ -159,8 +163,16 @@ input::-webkit-inner-spin-button {
 -webkit-appearance: none;
 margin: 0;
 }
-.border{
-    border: 1px solid #EEEEEE;
+
+.border {
+    border-top: 1px solid #EEEEEE;
+    border-left: 1px solid #EEEEEE;
+    border-right: 1px solid #EEEEEE;
+}
+
+/* 非活躍狀態才加下邊框 */
+.inactive-tab {
+    border-bottom: 1px solid #EEEEEE;
 }
 .informationInput{
     padding: 20px;


### PR DESCRIPTION
# issue #43
## google 登入按鈕放到註冊頁面
順便調整了登入註冊頁面的版面
![image](https://github.com/user-attachments/assets/ddea5859-dbde-4c1c-ba36-0ee205a7ef72)
## 重定向
- 如果已登入的使用者嘗試進入燈入夜面 => 導向 users/edit
- 如果未登入的使用者嘗試進入需要登入的頁面 => 導向 users/sign-in
- 被導向 users/sign-in 的使用者 google 登入後會回到原本的頁面
## 用加入購物車按鈕試做重定向
### 沒登入會跳錯誤
![image](https://github.com/user-attachments/assets/e836a0ae-cb09-4d70-b2fa-2c65b93cef80)
### 導向燈入夜，路徑上會帶之前的頁面
![image](https://github.com/user-attachments/assets/b4eefbaf-f99d-40c2-9d15-3e8e33b14d14)
### 登入後回到原本的頁面（localStorage 多了 UID 跟 TwT )
![image](https://github.com/user-attachments/assets/3eaa12e5-8468-4ab2-8645-044124b8233a)
