### PR TITLE
feat: #75 新增商品到共享購物車

### DIFF
--- a/src/components/AddSharedCart.vue
+++ b/src/components/AddSharedCart.vue
@@ -17,6 +17,9 @@ const form = reactive({
 onMounted(async () => {
   await SharedCartStore.getAllUserEmail()
 })
+
+const emits = defineEmits(["createdSharedCart"])
+
 const createSharedCart = async () => {
   const JWT = localStorage.getItem("TwT")
   const { email: userEmail, userId } = jwtDecode(JWT)
@@ -40,6 +43,8 @@ const createSharedCart = async () => {
   try {
     await SharedCartStore.creatSharedCart(form.name, userId, form.email)
     dialogFormVisible.value = false
+    // 這裡是為了讓 在商品詳情創建共享購物車後 重新 fetch 一次資料
+    emits("createdSharedCart")
     ElMessage.success("添加成功")
     await SharedCartStore.fetchSharedCartList(userId)
   } catch (err) {

--- a/src/stores/cart.js
+++ b/src/stores/cart.js
@@ -3,18 +3,17 @@ import axios from "axios"
 
 export const useCartStore = defineStore("cart", () => {
   // 新增商品到購物車 API
-  const addProduct = async (productId) => {
+  const addProduct = async (productId, quantity = 1) => {
     try {
       const userId = localStorage.getItem("UID")
       const { data } = await axios.post(`${import.meta.env.VITE_API_URL}/cart/cartInsert`, {
         user_id: userId,
         product_id: productId,
-        quantity: 1,
+        quantity,
       })
       return data
     } catch (err) {
       console.log(err)
-
       return err
     }
   }

--- a/src/stores/sharedCart.js
+++ b/src/stores/sharedCart.js
@@ -97,6 +97,20 @@ export const useSharedCartStore = defineStore("sharedCart", () => {
     }
   }
 
+  // 將商品新增到共享購物車
+  const addProductToSharedCart = async (groupId, productId, quantity = 1) => {
+    try {
+      const { data } = await axios.post(`${import.meta.env.VITE_API_URL}/sharedCart/addProduct/${groupId}`, {
+        productId,
+        quantity,
+      })
+      return data
+    } catch (err) {
+      console.error("添加商品到共享購物車失敗:", err)
+      throw err
+    }
+  }
+
   return {
     sharedCartList,
     fetchSharedCartList,
@@ -106,5 +120,6 @@ export const useSharedCartStore = defineStore("sharedCart", () => {
     creatSharedCart,
     deleteSharedCart,
     addMemberToSharedCart,
+    addProductToSharedCart,
   }
 })

--- a/src/views/Cart.vue
+++ b/src/views/Cart.vue
@@ -31,8 +31,6 @@ const itemPrice = computed(() => {
 // method
 // 獲取購物車商品
 const fetchCartItems = async () => {
-  console.log("userId", userId)
-
   try {
     const response = await axios.get(`${import.meta.env.VITE_API_URL}/cart/cartQuery`, {
       headers: {
@@ -40,7 +38,6 @@ const fetchCartItems = async () => {
       },
     })
     products.value = response.data // 將 API 返回的資料存入 products
-    console.log("資料獲取成功:", products.value)
   } catch (error) {
     console.error("獲取資料失敗:", error)
   }

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -16,6 +16,7 @@ const SharedCartStore = useSharedCartStore()
 const CartStore = useCartStore()
 const { sharedCartList } = storeToRefs(SharedCartStore)
 Swiper.use([Pagination, Navigation, Scrollbar])
+import AddSharedCart from "@/components/AddSharedCart.vue"
 
 const swiperInstance = ref(null)
 const route = useRoute()
@@ -228,26 +229,48 @@ const handleConfirm = async () => {
     ElMessage.error("加入共享購物車失敗")
   }
 }
+// 創建共享購物車後重新取得列表
+const refreshSharedCartList = async () => {
+  await SharedCartStore.fetchSharedCartList(userId)
+  sharedCartNames.value = sharedCartList.value.map((cart) => ({
+    id: cart.id,
+    name: cart.name || `您與 ${cart.member[0]} 與其他 ${cart.member.length - 1} 人共享的購物車`,
+  }))
+  dialogToggle.value = true
+}
 </script>
 
 <template>
   <section>
     <!-- 共享購物車選擇對話框 -->
-    <el-dialog v-model="dialogToggle" title="選擇共享購物車" width="30%">
-      <el-checkbox-group v-model="selectedCarts">
-        <div v-for="cart in sharedCartNames" :key="cart.id" class="cart-item">
-          <el-checkbox :value="cart.id" :label="cart.name">
-            {{ cart.name }}
-          </el-checkbox>
-        </div>
-      </el-checkbox-group>
-      <template #footer>
-        <span class="dialog-footer">
-          <el-button @click="dialogToggle = false">取消</el-button>
-          <el-button type="primary" @click="handleConfirm">確認</el-button>
-        </span>
-      </template>
-    </el-dialog>
+    <div v-if="sharedCartList.length === 0">
+      <el-dialog v-model="dialogToggle" title="您還沒有共享購物車" width="30%">
+        <AddSharedCart @createdSharedCart="refreshSharedCartList" />
+        <template #footer>
+          <span class="dialog-footer">
+            <el-button @click="dialogToggle = false">取消</el-button>
+          </span>
+        </template>
+      </el-dialog>
+    </div>
+    <div v-else>
+      <el-dialog v-model="dialogToggle" title="選擇共享購物車" width="30%">
+        <el-checkbox-group v-model="selectedCarts">
+          <div v-for="cart in sharedCartNames" :key="cart.id" class="cart-item">
+            <el-checkbox :value="cart.id" :label="cart.name">
+              {{ cart.name }}
+            </el-checkbox>
+          </div>
+        </el-checkbox-group>
+        <template #footer>
+          <span class="dialog-footer">
+            <el-button @click="dialogToggle = false">取消</el-button>
+            <el-button type="primary" @click="handleConfirm">確認</el-button>
+          </span>
+        </template>
+      </el-dialog>
+    </div>
+
     <div class="loading bg-lightBlue-300 my-8 max-w-full">
       <div class="profile">
         <!-- 輪播圖 -->


### PR DESCRIPTION
# issue #75 
- 還沒有共享購物車，可以在詳情頁直接創建（但目前一次只能創建一個）
- 創建後會重渲染取得共享購物車列表（用 emit 傳事件給父層）
- 使用者可以選擇這個商品要加到哪幾個共享購物車
- 如果有複數個，會打多次新增商品的 API（用 Promise.all + map 處理）
- 新增成功會顯示成功新增幾個這個商品到幾個共享購物車
---
### 如果沒有共享購物車
![image](https://github.com/user-attachments/assets/ea6af8ab-c9cc-4d9a-9723-dccfabe5098b)
### 亂打也會報錯
![image](https://github.com/user-attachments/assets/80d69673-b308-4ab4-8de9-2ef044b5b3f1)
### 新增後自動出現在彈窗的列表
![image](https://github.com/user-attachments/assets/d8553522-dd68-4536-ab84-484ac2ef6da8)
### 有多個共享購物車的話可以多選
![image](https://github.com/user-attachments/assets/0ce46d72-74d2-4e90-b181-09f713c4b313)
### 成功訊息會顯示商品數量、加到幾個共享購物車
![image](https://github.com/user-attachments/assets/2266b90f-327c-4b97-a703-7c8d353a22e7)
![image](https://github.com/user-attachments/assets/7a795db9-d40f-42bb-bf3a-8026bc3abd5a)
### 購物車頁面正常顯示
![image](https://github.com/user-attachments/assets/e39cf5c7-92c4-467a-b01f-1769778cfb36)

